### PR TITLE
cop-24 Phrase-теги после нормализации всегда уходят на новую строку

### DIFF
--- a/src/main/java/ru/kbakaras/cop/PublishCommand.java
+++ b/src/main/java/ru/kbakaras/cop/PublishCommand.java
@@ -46,7 +46,7 @@ public class PublishCommand implements Callable<Integer> {
             parent.setContentValue(content, pageSource);
 
             Content newContent = api.createContent(content);
-            if (!pageSource.sha1.equals(newContent.sha1())) {
+            if (pageSource.differentContent(newContent.getBody().getStorage().getValue())) {
                 log.warn("SHA1 of published content differs from converted, check converter");
             }
             // endregion

--- a/src/main/java/ru/kbakaras/cop/UpdateCommand.java
+++ b/src/main/java/ru/kbakaras/cop/UpdateCommand.java
@@ -65,14 +65,14 @@ public class UpdateCommand implements Callable<Integer> {
 
 
             // region Обновление основного содержимого страницы
-            if (!pageSource.sha1.equals(oldContent.sha1())) {
+            if (pageSource.differentContent(oldContent.getBody().getStorage().getValue())) {
                 Content content = new Content();
                 content.setVersion(oldContent.getVersion());
                 content.getVersion().setNumber(content.getVersion().getNumber() + 1);
                 parent.setContentValue(content, pageSource);
 
                 content = api.updateContent(oldContent.getId(), content);
-                if (!pageSource.sha1.equals(content.sha1())) {
+                if (pageSource.differentContent(content.getBody().getStorage().getValue())) {
                     log.warn("SHA1 of updated content differs from converted, check converter");
                 }
             }

--- a/src/main/java/ru/kbakaras/cop/confluence/dto/Content.java
+++ b/src/main/java/ru/kbakaras/cop/confluence/dto/Content.java
@@ -4,11 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.commons.codec.digest.DigestUtils;
-import org.htmlcleaner.CleanerProperties;
-import org.htmlcleaner.HtmlCleaner;
-import org.htmlcleaner.PrettyXmlSerializer;
-import org.htmlcleaner.TagNode;
 
 @Data
 @NoArgsConstructor
@@ -31,19 +26,5 @@ public class Content {
     private Ancestor[] ancestors;
 
     private ContentBody body;
-
-
-    public String sha1() {
-
-        HtmlCleaner cleaner = new HtmlCleaner();
-
-        CleanerProperties props = cleaner.getProperties();
-        props.setOmitHtmlEnvelope(true);
-        props.setOmitXmlDeclaration(true);
-
-        TagNode node = cleaner.clean(body.getStorage().getValue());
-
-        return DigestUtils.sha1Hex(new PrettyXmlSerializer(cleaner.getProperties()).getAsString(node));
-    }
 
 }

--- a/src/main/java/ru/kbakaras/cop/model/PageSource.java
+++ b/src/main/java/ru/kbakaras/cop/model/PageSource.java
@@ -1,6 +1,10 @@
 package ru.kbakaras.cop.model;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.htmlcleaner.CleanerProperties;
+import org.htmlcleaner.HtmlCleaner;
+import org.htmlcleaner.PrettyHtmlSerializer;
+import org.htmlcleaner.TagNode;
 
 import java.util.List;
 
@@ -8,16 +12,43 @@ public class PageSource {
 
     public final String title;
     public final String content;
-    public final String sha1;
+    private final String sha1;
 
     public final List<ImageSource> imageSourceList;
 
 
-    public PageSource(String title, String content, List<ImageSource> imageSourceList) {
+    public PageSource(String title, TagNode content, List<ImageSource> imageSourceList) {
         this.title = title;
-        this.content = content;
-        this.sha1 = DigestUtils.sha1Hex(content);
+        this.content = serializeContent(content);
+        this.sha1 = DigestUtils.sha1Hex(this.content);
         this.imageSourceList = imageSourceList;
+    }
+
+    public boolean differentContent(String htmlContent) {
+        return !sha1.equals(DigestUtils.sha1Hex(serializeContent(cleanContent(htmlContent))));
+    }
+
+
+    public static TagNode cleanContent(String htmlContent) {
+
+        HtmlCleaner cleaner = new HtmlCleaner();
+
+        CleanerProperties props = cleaner.getProperties();
+        props.setOmitHtmlEnvelope(true);
+        props.setOmitXmlDeclaration(true);
+
+        return cleaner.clean(htmlContent);
+    }
+
+    public static String serializeContent(TagNode node) {
+
+        HtmlCleaner cleaner = new HtmlCleaner();
+
+        CleanerProperties props = cleaner.getProperties();
+        props.setOmitHtmlEnvelope(true);
+        props.setOmitXmlDeclaration(true);
+
+        return new PrettyHtmlSerializer(cleaner.getProperties()).getAsString(node);
     }
 
 }


### PR DESCRIPTION
Перешёл на использование сериализатора PrettyHtmlSerializer вместо PrettyXmlSerializer, он более чувствителен к белому пространству. Всё остальное -- лишь сопутствующие улучшения.

Closes #32.