### PR TITLE
cop-37 Обрабатывать ссылки на файлы как аттачменты

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.11</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
             <version>${version.picocli}</version>

--- a/src/main/java/ru/kbakaras/cop/PublishCommand.java
+++ b/src/main/java/ru/kbakaras/cop/PublishCommand.java
@@ -54,10 +54,10 @@ public class PublishCommand implements Callable<Integer> {
 
             // region Загрузка изображений
             pageSource
-                    .imageSourceList
+                    .attachmentSourceList
                     .forEach(imageSource -> {
                         try {
-                            api.createAttachment(newContent.getId(), imageSource.name, imageSource.data);
+                            api.createAttachment(newContent.getId(), imageSource.name, imageSource.mime, imageSource.data);
                         } catch (URISyntaxException | IOException e) {
                             throw new RuntimeException(e);
                         }

--- a/src/main/java/ru/kbakaras/cop/UpdateCommand.java
+++ b/src/main/java/ru/kbakaras/cop/UpdateCommand.java
@@ -6,8 +6,8 @@ import ru.kbakaras.cop.confluence.ConfluenceApi;
 import ru.kbakaras.cop.confluence.dto.Attachment;
 import ru.kbakaras.cop.confluence.dto.Content;
 import ru.kbakaras.cop.confluence.dto.ContentList;
-import ru.kbakaras.cop.model.ImageDestination;
-import ru.kbakaras.cop.model.ImageSource;
+import ru.kbakaras.cop.model.AttachmentDestination;
+import ru.kbakaras.cop.model.AttachmentSource;
 import ru.kbakaras.cop.model.PageSource;
 import ru.kbakaras.sugar.utils.CollectionUpdater;
 
@@ -80,18 +80,18 @@ public class UpdateCommand implements Callable<Integer> {
 
 
             // region Обновление изображений (вложений)
-            List<ImageDestination> destinationImages = new ArrayList<>();
+            List<AttachmentDestination> destinationImages = new ArrayList<>();
             for (Attachment attachment : api.findAttachmentByContentId(oldContent.getId()).getResults()) {
-                destinationImages.add(new ImageDestination(attachment, api.getAttachmentData(attachment)));
+                destinationImages.add(new AttachmentDestination(attachment, api.getAttachmentData(attachment)));
             }
 
-            new CollectionUpdater<ImageDestination, ImageSource, String>(id -> id.name, is -> is.name)
+            new CollectionUpdater<AttachmentDestination, AttachmentSource, String>(id -> id.name, is -> is.name)
 
                     .check4Changes((id, is) -> !id.sha1.equals(is.sha1))
 
                     .createElement(is -> {
                         try {
-                            api.createAttachment(oldContent.getId(), is.name, is.data);
+                            api.createAttachment(oldContent.getId(), is.name, is.mime, is.data);
                         } catch (URISyntaxException | IOException e) {
                             throw new RuntimeException(e);
                         }
@@ -105,7 +105,7 @@ public class UpdateCommand implements Callable<Integer> {
                         }
                     })
 
-                    .collection(destinationImages, pageSource.imageSourceList);
+                    .collection(destinationImages, pageSource.attachmentSourceList);
             // endregion
 
         }

--- a/src/main/java/ru/kbakaras/cop/confluence/ConfluenceApi.java
+++ b/src/main/java/ru/kbakaras/cop/confluence/ConfluenceApi.java
@@ -93,12 +93,12 @@ public class ConfluenceApi implements Closeable {
         response.assertStatusCode(200);
     }
 
-    public void createAttachment(String contentId, String fileName, byte[] data) throws URISyntaxException, IOException {
+    public void createAttachment(String contentId, String fileName, String fileMime, byte[] data) throws URISyntaxException, IOException {
         URIBuilder uriBuilder = new URIBuilder(String.format(
                 baseUrl + "/rest/api/content/%s/child/attachment", contentId));
         HttpEntity entity = MultipartEntityBuilder
                 .create()
-                .addBinaryBody("file", data, ContentType.IMAGE_PNG, fileName)
+                .addBinaryBody("file", data, ContentType.parse(fileMime), fileName)
                 .setMode(HttpMultipartMode.BROWSER_COMPATIBLE)
                 .setCharset(StandardCharsets.UTF_8)
                 .build();

--- a/src/main/java/ru/kbakaras/cop/model/AttachmentDestination.java
+++ b/src/main/java/ru/kbakaras/cop/model/AttachmentDestination.java
@@ -3,14 +3,14 @@ package ru.kbakaras.cop.model;
 import org.apache.commons.codec.digest.DigestUtils;
 import ru.kbakaras.cop.confluence.dto.Attachment;
 
-public class ImageDestination {
+public class AttachmentDestination {
 
     public final String name;
     public final Attachment attachment;
     public final String sha1;
 
 
-    public ImageDestination(Attachment attachment, byte[] imageData) {
+    public AttachmentDestination(Attachment attachment, byte[] imageData) {
         this.name = attachment.getTitle();
         this.attachment = attachment;
         this.sha1 = DigestUtils.sha1Hex(imageData);

--- a/src/main/java/ru/kbakaras/cop/model/AttachmentSource.java
+++ b/src/main/java/ru/kbakaras/cop/model/AttachmentSource.java
@@ -3,18 +3,22 @@ package ru.kbakaras.cop.model;
 import lombok.SneakyThrows;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.tika.Tika;
 
 import java.io.File;
 
-public class ImageSource {
+public class AttachmentSource {
 
     public final String name;
+    public final String mime;
     public final byte[] data;
     public final String sha1;
 
     @SneakyThrows
-    public ImageSource(File imageFile) {
+    public AttachmentSource(File imageFile) {
+
         name = imageFile.getName();
+        mime = new Tika().detect(imageFile);
         data = FileUtils.readFileToByteArray(imageFile);
         sha1 = DigestUtils.sha1Hex(data);
     }

--- a/src/main/java/ru/kbakaras/cop/model/PageSource.java
+++ b/src/main/java/ru/kbakaras/cop/model/PageSource.java
@@ -1,9 +1,10 @@
 package ru.kbakaras.cop.model;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.htmlcleaner.CleanerProperties;
 import org.htmlcleaner.HtmlCleaner;
-import org.htmlcleaner.PrettyHtmlSerializer;
+import org.htmlcleaner.SimpleXmlSerializer;
 import org.htmlcleaner.TagNode;
 
 import java.util.List;
@@ -14,14 +15,14 @@ public class PageSource {
     public final String content;
     private final String sha1;
 
-    public final List<ImageSource> imageSourceList;
+    public final List<AttachmentSource> attachmentSourceList;
 
 
-    public PageSource(String title, TagNode content, List<ImageSource> imageSourceList) {
+    public PageSource(String title, TagNode content, List<AttachmentSource> attachmentSourceList) {
         this.title = title;
         this.content = serializeContent(content);
         this.sha1 = DigestUtils.sha1Hex(this.content);
-        this.imageSourceList = imageSourceList;
+        this.attachmentSourceList = attachmentSourceList;
     }
 
     public boolean differentContent(String htmlContent) {
@@ -32,11 +33,8 @@ public class PageSource {
     public static TagNode cleanContent(String htmlContent) {
 
         HtmlCleaner cleaner = new HtmlCleaner();
-
-        CleanerProperties props = cleaner.getProperties();
-        props.setOmitHtmlEnvelope(true);
-        props.setOmitXmlDeclaration(true);
-        props.setDeserializeEntities(true);
+        setProperties(cleaner)
+                .setDeserializeEntities(true);
 
         return cleaner.clean(htmlContent);
     }
@@ -44,12 +42,19 @@ public class PageSource {
     public static String serializeContent(TagNode node) {
 
         HtmlCleaner cleaner = new HtmlCleaner();
+        setProperties(cleaner);
 
+
+        return StringUtils.chomp(
+                new SimpleXmlSerializer(cleaner.getProperties()).getAsString(node)
+        );
+    }
+
+    public static CleanerProperties setProperties(HtmlCleaner cleaner) {
         CleanerProperties props = cleaner.getProperties();
         props.setOmitHtmlEnvelope(true);
         props.setOmitXmlDeclaration(true);
-
-        return new PrettyHtmlSerializer(cleaner.getProperties()).getAsString(node);
+        return props;
     }
 
 }


### PR DESCRIPTION
1. В конверторе доработана логика формирования ссылки: если не указана схема URI, ссылка считается ссылкой на аттачмент и формируются соответствующие теги.
2. В API-методе по созданию нового аттачмента в Confluence добавлен параметр для указания mime-типа.
3. Классы для работы с приложенными изображениями переименованы с префиксом Attachment, их функциональность соответственно обобщена.
4. Добавлена зависимость на Apache Tika для определения mime-типов для файлов аттачментов.

Closes #37.