### PR TITLE
cop-54 Если для изображения не указано выравнивание, в документ попадает строка `null`

### DIFF
--- a/cop-app/src/main/java/ru/kbakaras/cop/adoc/ConfluenceConverter.java
+++ b/cop-app/src/main/java/ru/kbakaras/cop/adoc/ConfluenceConverter.java
@@ -147,7 +147,6 @@ public class ConfluenceConverter extends StringConverter {
 
             imageBuilder
                     .append("<p>")
-
                     .append("<ac:image");
 
             Optional.ofNullable(block.getAttribute("align"))


### PR DESCRIPTION
Closes #54.